### PR TITLE
add explicit link to Impressum

### DIFF
--- a/app/views/share/_footer.html.haml
+++ b/app/views/share/_footer.html.haml
@@ -6,4 +6,4 @@
       &ndash; a frontend for the Git-based
       =link_to "Gollum","https://github.com/github/gollum"
       ="-Wiki."
-    %li{:class => "right"}= link_to t "Impressum"
+    %li{:class => "right"}= link_to t("Impressum"), meutewiki_show_page_path("Impressum")


### PR DESCRIPTION
the Impressum should link to a wiki-page, that contains the actual
Impressum. There might be a problem with this, because everybody with
edit rights to the wiki can change the impressum, now. Therefore the
wiki needs a "lock"-feature someday. So a wiki-page might be locked to a
specific version or something like that. Anyway, this problem should be
handled elsewhere, not at this point.

This targets Issue MetaMeute/anduin#8
